### PR TITLE
Add Buy Me a Coffee links for open-source projects

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -27,6 +27,13 @@ Hi, I'm Isaac. I build applications and break things on purpose to learn how the
 - [**git commits**](https://cbea.ms/git-commit/)
 - [**User Inyerface**](https://userinyerface.com/index.html)
 
+## Open source I ship
+
+- [**Spotiglass**](https://github.com/isaaclins/spotiglass) — native macOS Spotify client (SwiftUI)
+- [**PowerUserMail**](https://github.com/isaaclins/powerusermail) — keyboard-first email for macOS
+
+If a project saved you time, a coffee funds fixes, docs, and releases: [buymeacoffee.com/isaaclins](https://buymeacoffee.com/isaaclins)
+
 ## Contact Me
 
 - **Email:** [contact@isaaclins.com](mailto:contact@isaaclins.com)

--- a/layouts/footer.md
+++ b/layouts/footer.md
@@ -1,4 +1,4 @@
 ---
 
 © 2026 Isaac Lins. All rights reserved.  
-[LinkedIn](https://www.linkedin.com/in/isaaclinsdotcom/) | [GitHub](https://github.com/isaaclins) | [Mail](mailto:contact@isaaclins.com)
+[LinkedIn](https://www.linkedin.com/in/isaaclinsdotcom/) | [GitHub](https://github.com/isaaclins) | [Mail](mailto:contact@isaaclins.com) | [Buy Me a Coffee](https://buymeacoffee.com/isaaclins)


### PR DESCRIPTION
## Summary
- Homepage: Spotiglass + PowerUserMail links with [Buy Me a Coffee](https://buymeacoffee.com/isaaclins)
- Footer: BMAC link alongside contact links

## Why
Organic tips from site traffic; pairs with README/FUNDING.yml on the macOS apps.

## Test plan
- [ ] `hugo server` — homepage renders new section
- [ ] Footer shows BMAC link on all pages