### PR TITLE
fix(ci): restore Pages deploy when build-test dispatch fails

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -2,6 +2,7 @@
 name: deploy-hugo
 
 on:
+  workflow_dispatch:
   workflow_run:
     workflows: ["build-test"]
     types:

--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -1,0 +1,74 @@
+# Direct Hugo build + GitHub Pages deploy (bypasses broken workflow_dispatch on build-test)
+name: pages-deploy
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages-deploy
+  cancel-in-progress: false
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      HUGO_VERSION: 0.140.2
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
+
+      - name: Install Hugo CLI
+        run: |
+          wget -O ${{ runner.temp }}/hugo.deb "https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb"
+          sudo dpkg -i ${{ runner.temp }}/hugo.deb
+
+      - name: Verify Hugo Version
+        run: hugo version
+
+      - name: Install Dart Sass
+        run: sudo snap install dart-sass
+
+      - name: Setup Pages
+        id: pages
+        uses: actions/configure-pages@v4
+
+      - name: Install Node.js dependencies
+        run: "[[ -f package-lock.json || -f npm-shrinkwrap.json ]] && npm ci || true"
+
+      - name: Build with Hugo
+        env:
+          HUGO_ENVIRONMENT: production
+          HUGO_ENV: production
+        run: |
+          hugo --gc --minify --baseURL "${{ steps.pages.outputs.base_url }}/"
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./public
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary
- Adds `pages-deploy` workflow: Hugo build + GitHub Pages on `push` to `main` and `workflow_dispatch` with OIDC permissions (`contents: read`, `pages: write`, `id-token: write`).
- Adds `workflow_dispatch` to `deploy-hugo` for manual redeploys.

## Problem
- BMAC content merged in #44 but live site Last-Modified still 2026-05-21.
- `gh workflow run build-test.yml` fails with HTTP 500.
- No Actions runs since May 21 despite pushes on main.

## Test plan
- [ ] Merge and confirm `pages-deploy` run on main succeeds
- [ ] Verify https://isaaclins.com shows buymeacoffee links