### PR TITLE
feat: Markdown + llms.txt for AI agents

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -68,7 +68,8 @@ target = 'static/images'
   complexity = "complexity"
 
 [outputs]
-  page    = ["HTML", "twitterpreview"]
+  home    = ["HTML", "RSS", "llms"]
+  page    = ["HTML", "twitterpreview", "markdown"]
   section = ["HTML", "RSS", "JSON"]
 
 # Per-page social-card preview page (see layouts/_default/single.twitterpreview.html).
@@ -78,4 +79,16 @@ target = 'static/images'
     mediaType      = "text/html"
     baseName       = "twitterpreview"
     isHTML         = true
+    notAlternative = true
+
+  [outputFormats.markdown]
+    mediaType      = "text/markdown"
+    baseName       = "index"
+    isPlainText    = true
+    notAlternative = true
+
+  [outputFormats.llms]
+    mediaType      = "text/plain"
+    baseName       = "llms"
+    isPlainText    = true
     notAlternative = true

--- a/layouts/_default/single.md
+++ b/layouts/_default/single.md
@@ -1,0 +1,10 @@
+{{- /* Per-page Markdown for AI agents. Bound to the `markdown` output format
+       (suffix .md) for every regular page. isPlainText is set on the format so
+       content is emitted raw, not HTML-escaped. */ -}}
+# {{ .Title }}
+
+{{ with .Description }}{{ . }}
+
+{{ end }}*Source: {{ .Permalink }}*
+
+{{ .RawContent }}

--- a/layouts/index.llms.txt
+++ b/layouts/index.llms.txt
@@ -1,0 +1,14 @@
+{{- /* Root /llms.txt — index of blog posts linking to their Markdown views.
+       Bound to the `llms` output format on the home page. */ -}}
+# {{ .Site.Title }}
+
+{{ with .Site.Params.description }}> {{ . }}
+
+{{ end }}## Blog posts
+
+{{ range (sort (where .Site.RegularPages "Section" "blog") "Date" "desc") -}}
+{{ $p := . -}}
+{{ with .OutputFormats.Get "markdown" -}}
+- [{{ $p.Title }}]({{ .Permalink }}){{ with $p.Description }}: {{ . }}{{ end }}
+{{ end -}}
+{{ end -}}


### PR DESCRIPTION
## Summary

Adds a Markdown / `llms.txt` view of the site for AI agents and LLM tools, generated at build time. Follow-up to #47 (now merged); branches off the current `main`.

Because this is a Hugo site, the clean Markdown source for every page already exists at build time — so this needs no paid edge "HTML→Markdown" conversion, no Cloudflare Worker, and no plan upgrade. It ships as plain static files on the existing GitHub Pages + Cloudflare stack.

`3 files changed` (`config.toml` + two small templates).

## What it does

- Defines two Hugo output formats (`markdown`, `llms`) and wires them into `[outputs]`.
- Emits a sibling **`index.md`** next to each page's `index.html` (e.g. `/blog/<slug>/index.md`) containing the page's source Markdown (`# Title`, description, a `*Source:*` link, then the body).
- Emits a root **`/llms.txt`** index listing every blog post and linking to its `.md`.

## Verification

- `hugo --gc --minify` → exit 0 on top of current `main`.
- 28 pages get an `index.md`; `/llms.txt` lists all blog posts with `.md` links.
- Markdown is emitted raw (not HTML-escaped); no `+++` front matter leaks in.
- No regression: `index.html`, `index.xml`, and the `blog/index.json` search index all still build; the merged #47 changes (README, `<picture>`/WebP, referrer meta, local fuse.js) remain intact in the combined build.

## Design notes

- Body uses the page's real source Markdown (`.RawContent`) — lossless headings/code/links/tables. Shortcode calls appear as literal tags in the 3 of 30 posts that use them; an accepted minor cosmetic. Stripping them is a one-line future tweak (documented in the layout comment / plan).
- No content negotiation (same URL returning Markdown on `Accept: text/markdown`). If you ever want that, a small Cloudflare Worker can serve these prebuilt `.md` files — they're exactly what it would return.
- New top-level content sections won't appear in `/llms.txt` until added to the section filter in `layouts/index.llms.txt`.
