### PR TITLE
Close six homepage redesign follow-ups (#53-#58)

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -760,6 +760,28 @@ img.thick-border {
   margin-top: 2rem;
 }
 
+// -------------- SKIP LINK -------------- //
+// Hidden off-screen until keyboard focus, then placed above the nav.
+
+.skip-link.skip-link {
+  position: absolute;
+  left: -100vw;
+  top: var(--sp-2);
+  z-index: 1;
+  padding: var(--sp-2) var(--sp-3);
+  background: var(--fg);
+  color: var(--bg);
+
+  &:visited {
+    color: var(--bg);
+  }
+
+  &:focus,
+  &:focus-visible {
+    left: var(--sp-4);
+  }
+}
+
 // -------------- SITE NAV -------------- //
 // Slim persistent bar: name left, sections right. Static, no JS.
 
@@ -961,6 +983,20 @@ img.thick-border {
   }
 }
 
+// Writing titles stay in the text colour until the reader points at them.
+.writing .writing-item a {
+  color: var(--fg);
+
+  &:visited {
+    color: var(--fg);
+  }
+
+  &:hover,
+  &:focus-visible {
+    color: var(--accent);
+  }
+}
+
 .writing-date {
   color: var(--muted);
   font-size: var(--fs-meta);
@@ -1032,7 +1068,8 @@ img.thick-border {
 // Navigation is not useful on paper. The resume layout already ships without
 // any chrome; this covers posts and pages printed or saved as PDF.
 @media print {
-  .site-nav {
+  .site-nav,
+  .skip-link {
     display: none;
   }
 }

--- a/config.toml
+++ b/config.toml
@@ -1,5 +1,5 @@
 baseURL = "https://isaaclins.com"
-languageCode = "en-us"
+locale = "en-us"
 title = "Isaac Lins"
 enableRobotsTXT = true
 

--- a/content/reading.md
+++ b/content/reading.md
@@ -2,6 +2,7 @@
 title = "Reading"
 date = 2026-08-04
 draft = false
+show_date = false
 description = "The short list of sites and ideas that shaped how I work: keep it simple, say the thing, write the commit message properly."
 +++
 

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,9 +1,10 @@
 <!DOCTYPE html>
-<html lang="{{ $.Site.LanguageCode }}">
+<html lang="{{ site.Language.Locale }}">
     {{- partial "head.html" . -}}
     <body a="{{ $.Site.Params.theme_config.appearance | default "auto" }}">
+        <a class="skip-link" href="#content">skip to content</a>
         {{ partial "site_nav.html" . }}
-        <main class="page-content" aria-label="Content">
+        <main class="page-content" id="content" aria-label="Content">
             <div class="w">
                 {{ if and .IsSection (eq .Section "blog") }}
                 <div id="search-popup" class="search-popup">

--- a/layouts/_default/latest.html
+++ b/layouts/_default/latest.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{ .Site.LanguageCode | default "en" }}">
+<html lang="{{ site.Language.Locale | default "en" }}">
 <head>
     <title>Redirecting to Latest Post</title>
     {{ $latestInBlogSection := first 1 (where .Site.RegularPages.ByDate.Reverse "Section" "blog") }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -2,11 +2,13 @@
 "back_link.html" .}}
 
 <article>
+  {{ if ne .Params.show_date false }}
   <p class="post-meta">
     <time datetime="{{ .Date }}">
       {{ .Date | time.Format site.Params.theme_config.date_format }}
     </time>
   </p>
+  {{ end }}
   
   {{ if .Params.tags }}
   <p class="post-tags">

--- a/layouts/posts/baseof.html
+++ b/layouts/posts/baseof.html
@@ -1,9 +1,10 @@
 <!DOCTYPE html>
-<html lang="{{ $.Site.LanguageCode }}">
+<html lang="{{ site.Language.Locale }}">
     {{- partial "head.html" . -}}
     <body a="{{ $.Site.Params.theme_config.appearance | default "auto" }}">
+        <a class="skip-link" href="#content">skip to content</a>
         {{ partial "site_nav.html" . }}
-        <main class="page-content" aria-label="Content">
+        <main class="page-content" id="content" aria-label="Content">
             <div class="w">
                 <div class="post-meta">
                     {{ partial "back_link.html" .}}

--- a/layouts/resume/baseof.html
+++ b/layouts/resume/baseof.html
@@ -1,8 +1,10 @@
 <!DOCTYPE html>
-<html lang="{{ $.Site.LanguageCode }}">
+<html lang="{{ site.Language.Locale }}">
     {{- partial "head.html" . -}}
     <body a="{{ $.Site.Params.theme_config.appearance | default "auto" }}">
-        <main class="page-content" aria-label="Content">
+        <a class="skip-link" href="#content">skip to content</a>
+        {{ partial "site_nav.html" . }}
+        <main class="page-content" id="content" aria-label="Content">
             <div class="w">
                 {{- block "main" . }}{{- end }}
                 {{/* No footer for resume - cleaner for PDF export */}}

--- a/scripts/check-draft-status.py
+++ b/scripts/check-draft-status.py
@@ -5,6 +5,8 @@ Warns (but doesn't fail) when committing draft posts to main.
 This is informational - sometimes you want to commit drafts.
 """
 
+from __future__ import annotations
+
 import sys
 import re
 from pathlib import Path

--- a/scripts/check-image-paths.py
+++ b/scripts/check-image-paths.py
@@ -4,6 +4,8 @@ Check that image paths referenced in markdown files actually exist.
 Validates both markdown image syntax and Hugo shortcodes.
 """
 
+from __future__ import annotations
+
 import sys
 import re
 from pathlib import Path

--- a/scripts/validate-frontmatter.py
+++ b/scripts/validate-frontmatter.py
@@ -4,6 +4,8 @@ Validate Hugo TOML frontmatter in markdown files.
 Checks for required fields and valid structure.
 """
 
+from __future__ import annotations
+
 import sys
 import re
 from pathlib import Path


### PR DESCRIPTION
Closes the six follow-up issues from the homepage redesign. All mechanical, no visual redesign.

**Stack:** this is PR 1 of 2. [`feat/projects-timeline`](https://github.com/isaaclins/isaaclins.github.io/tree/feat/projects-timeline) (issue #52) is stacked on top of this branch and should merge after it.

| Issue | Fix |
|---|---|
| #53 | `layouts/resume/baseof.html` gets the nav. Safe now that `@media print` hides `.site-nav`, so the PDF export stays clean. |
| #54 | New `show_date` front matter flag, honoured in `layouts/_default/single.html`, set to `false` in `content/reading.md`. Default is unchanged, so every blog post keeps its date. |
| #55 | Writing-list post titles now sit in the normal text colour, with the accent on `:hover` and `:focus-visible`. The blue itself is untouched. |
| #56 | `from __future__ import annotations` in the three `scripts/*.py` validators, which were crashing on the stock macOS Python 3.9 with `TypeError: unsupported operand type(s) for \|`. |
| #57 | `languageCode` to `locale`, and `.Site.LanguageCode` to `site.Language.Locale`. This was deprecated in Hugo v0.158 and slated for removal, and deploys run straight off `main`. |
| #58 | Skip-to-content link as the first focusable element in all three baseof templates, with `id="content"` on `<main>`. |

### Verified

- `hugo --gc --minify` is now **completely warning-free**. The two `languageCode` deprecation warnings were the last ones.
- `<html lang="en-us">` is byte-identical on `/`, `/blog/`, and `/resume/`, so #57 is a pure rename with no output change.
- `/reading/` no longer renders a date, while blog posts still do.
- Skip link and `id=content` present in the built output.

### Note

`layouts/_default/latest.html` also referenced `.Site.LanguageCode` and was updated, though it was not named in issue #57.
