### PR TITLE
Bump checkout, setup-node, setup-python to v7 (#28)

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -25,7 +25,7 @@ jobs:
       HUGO_VERSION: 0.140.2
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           submodules: recursive
           fetch-depth: 0
@@ -57,7 +57,7 @@ jobs:
       # BEGIN PAGE VALIDATION
       # ------------------------
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: "3.x"
 
@@ -71,7 +71,7 @@ jobs:
       # SPELL CHECK
       # ------------------------
       - name: Setup Node.js for cspell
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: "24"
 

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -14,7 +14,7 @@ jobs:
       urls: ${{ steps.get_urls.outputs.urls }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v3
@@ -56,7 +56,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Prepare URLs for Lighthouse
         id: prepare_lighthouse_urls

--- a/.github/workflows/optimize-images.yml
+++ b/.github/workflows/optimize-images.yml
@@ -28,10 +28,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: "24"
 

--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -27,7 +27,7 @@ jobs:
       HUGO_VERSION: 0.140.2
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           submodules: recursive
           fetch-depth: 0


### PR DESCRIPTION
Resolves the three GitHub Action major bumps tracked in issue #28, consolidated into one commit instead of three Renovate PRs.

Bumps `actions/checkout`, `actions/setup-node`, and `actions/setup-python` from v6 to v7 across all four workflows. Eight `uses:` lines, nothing else.

### Why each major is safe here

**checkout v7** ([release notes](https://github.com/actions/checkout/releases/tag/v7.0.0)) adds fork-PR protection for `pull_request_target` and qualifying `workflow_run` events, defaulting `allow-unsafe-pr-checkout` to `false`.

This repo has exactly one `workflow_run` trigger, in `lighthouse.yml`, and it chains off `pages-deploy`. That workflow runs only on push to `main` and on manual dispatch, so the `workflow_run` event can never originate from a fork pull request and the new protection never engages. No `pull_request_target` anywhere, and no checkout step overrides `ref:`.

**setup-node v7** ([release notes](https://github.com/actions/setup-node/releases/tag/v7.0.0)) migrates to ESM, adds cache-key outputs, and drops the dummy `NODE_AUTH_TOKEN` export. Both uses here request Node 24 with no cache or registry inputs, and the repo has no `package.json` or lockfile that could trigger automatic npm caching.

**setup-python v7** ([release notes](https://github.com/actions/setup-python/releases/tag/v7.0.0)) migrates to ESM and removes the `pip-install` input. The only use here sets `python-version: "3.x"` and installs `html5validator` in a separate shell step.

### Verified

- All four workflow files parse as valid YAML.
- No `actions/checkout@v6`, `setup-node@v6`, or `setup-python@v6` references remain.
- Diff touches `.github/workflows/` only.

### Follow-up

Renovate PRs #50 and #51 should be closed in favour of this branch, and #49 should stay closed.
