### PR TITLE
Replace the stack table with a projects timeline (#52)

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -963,13 +963,30 @@ img.thick-border {
 // follows the page scroll. The cards are deliberately quiet and slightly
 // imperfect, like a working notebook rather than a product grid.
 .timeline {
-  max-width: 100%;
-  margin: 0;
+  width: 100%;
+  max-width: var(--measure);
+  margin: 0 auto;
+  box-sizing: border-box;
+}
+
+// One row per project, plus an extra row for any project carrying the long
+// showcase text, so a tall card gets the space instead of colliding with its
+// neighbour. The runway is derived from that row count rather than hardcoded,
+// so adding a project or a long body cannot silently break the spacing.
+.timeline {
+  --timeline-step: 20vh;
+  --timeline-travel: calc(var(--timeline-step) * var(--timeline-steps));
+  --timeline-rail-top: calc(50vh - (var(--timeline-step) / 2));
+  --timeline-length: calc(100vh + var(--timeline-travel));
 }
 
 .timeline-track {
   position: relative;
-  height: 300vh;
+  width: 100%;
+  max-width: var(--measure);
+  height: var(--timeline-length);
+  margin-inline: auto;
+  box-sizing: border-box;
   view-timeline-name: --projects-track;
   view-timeline-axis: block;
 }
@@ -977,8 +994,12 @@ img.thick-border {
 .timeline-pin {
   position: sticky;
   top: 0;
+  width: 100%;
+  max-width: var(--measure);
   height: 100vh;
+  margin-inline: auto;
   overflow: hidden;
+  box-sizing: border-box;
   outline: none;
 
   &:focus-visible {
@@ -989,18 +1010,19 @@ img.thick-border {
 
 .timeline-inner {
   position: relative;
-  height: 300vh;
+  height: var(--timeline-length);
   min-height: 100%;
 }
 
 .timeline-rail {
   position: absolute;
-  top: var(--sp-6);
+  top: var(--timeline-rail-top);
   right: 0;
-  bottom: calc(var(--sp-6) + var(--sp-8));
+  bottom: auto;
   display: grid;
-  grid-template-rows: repeat(var(--timeline-items), minmax(0, 1fr));
-  width: 16%;
+  grid-template-rows: repeat(var(--timeline-rows), minmax(0, 1fr));
+  width: 28%;
+  height: calc(var(--timeline-step) * var(--timeline-rows));
   border-left: 1px solid var(--accent);
 }
 
@@ -1019,22 +1041,90 @@ img.thick-border {
   border-top: 1px solid var(--accent);
 }
 
-.timeline-tick-date {
+// A single date owns the middle of the rail. It lives outside the scrolling
+// layer, so it holds position while the cards travel past underneath. Each
+// label is visible only for the stretch where its own card is the one being
+// read, and the windows are adjacent rather than overlapping, so exactly one
+// date is ever on screen.
+.timeline-dates {
+  position: absolute;
+  top: 50%;
+  right: 0;
+  width: 28%;
+  height: 0;
+  pointer-events: none;
+}
+
+.timeline-date {
+  position: absolute;
+  top: -0.6em;
+  left: 0;
   margin-left: var(--sp-3);
   color: var(--accent);
   font-size: var(--fs-meta);
   line-height: 1.2;
   white-space: nowrap;
+  opacity: 0;
+  animation: timeline-date-cycle linear;
+  animation-timeline: --projects-track;
+  animation-range: var(--from) var(--to);
+}
+
+// The first project already owns the slot when the pin engages.
+.timeline-date--first {
+  animation-name: timeline-date-first;
+  animation-range: calc(var(--from) - 0.1%) var(--to);
+}
+
+.timeline-date--last {
+  animation-name: timeline-date-last;
+}
+
+@keyframes timeline-date-first {
+  0%,
+  86% {
+    opacity: 1;
+    transform: translateY(0);
+  }
+
+  100% {
+    opacity: 0;
+    transform: translateY(-1.4em);
+  }
+}
+
+// The middle labels switch at their range boundary, so one label remains
+// visible even on the exact handover frame.
+@keyframes timeline-date-cycle {
+  0%,
+  86% {
+    opacity: 1;
+    transform: translateY(0);
+  }
+
+  100% {
+    opacity: 0;
+    transform: translateY(-1.4em);
+  }
+}
+
+@keyframes timeline-date-last {
+  0%,
+  100% {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
 .timeline-cards {
   position: absolute;
-  top: var(--sp-6);
-  right: calc(16% + var(--sp-4));
-  bottom: calc(var(--sp-6) + var(--sp-8));
+  top: var(--timeline-rail-top);
+  right: calc(28% + var(--sp-4));
+  bottom: auto;
   left: 0;
   display: grid;
-  grid-template-rows: repeat(var(--timeline-items), minmax(0, 1fr));
+  grid-template-rows: repeat(var(--timeline-rows), minmax(0, 1fr));
+  height: calc(var(--timeline-step) * var(--timeline-rows));
 }
 
 .timeline-card {
@@ -1066,44 +1156,78 @@ img.thick-border {
 }
 
 .timeline-card-date {
-  margin: 0 0 var(--sp-2);
+  margin: 0 0 var(--sp-1);
   color: var(--muted);
   font-size: var(--fs-meta);
+  line-height: 1.2;
 }
 
 .timeline-card-title {
   margin: 0 0 var(--sp-2);
   font-size: var(--fs-body);
-  line-height: 1.3;
+  line-height: 1.2;
 }
 
 .timeline-card-description,
-.timeline-card-link {
+.timeline-card-links {
   font-size: var(--fs-meta);
-  line-height: 1.5;
+  line-height: 1.45;
 
   p {
     margin: 0;
   }
 }
 
-.timeline-card-link {
-  margin-top: var(--sp-3);
+// The long version of a project lives on its own page, so the card only needs
+// a way in. Read more sits first, then the source link.
+.timeline-card-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--sp-2) var(--sp-4);
+  margin-top: var(--sp-2);
+  font-size: var(--fs-meta);
+  line-height: 1.45;
+
+  p {
+    margin: 0;
+  }
 }
 
+.timeline-card-more {
+  white-space: nowrap;
+}
+
+// Bottom right, inside the rail gutter. The cards stop before this column, so
+// the hint never sits on top of card content.
+// Only useful before you have started. It fades out over the first stretch of
+// the pin so it stops competing with the cards.
 .timeline-scroll-hint {
   position: absolute;
-  bottom: var(--sp-4);
-  left: 50%;
+  right: 0;
+  bottom: var(--sp-2);
+  left: auto;
   margin: 0;
   padding: var(--sp-1) var(--sp-3);
-  transform: translateX(-50%);
+  transform: none;
   color: var(--muted);
   background: var(--bg);
   border: 1px solid var(--rule);
   font-size: var(--fs-label);
   letter-spacing: var(--tracking-label);
   white-space: nowrap;
+  animation: timeline-hint-fade linear both;
+  animation-timeline: --projects-track;
+  animation-range: var(--timeline-view-start) calc(var(--timeline-view-start) + 6%);
+}
+
+@keyframes timeline-hint-fade {
+  0% {
+    opacity: 1;
+  }
+
+  100% {
+    opacity: 0;
+  }
 }
 
 @keyframes timeline-pan {
@@ -1136,14 +1260,22 @@ img.thick-border {
     transform: none;
   }
 
-  .timeline-rail {
+  // No pinning means no middle slot to park in. The cards already print their
+  // dates, so the rail and floating labels are noise in the static layout.
+  .timeline-rail,
+  .timeline-dates {
     display: none;
   }
 
   .timeline-cards {
     position: static;
+    top: auto;
+    right: auto;
+    bottom: auto;
+    left: auto;
     display: grid;
     grid-template-rows: none;
+    height: auto;
     gap: var(--sp-5);
   }
 
@@ -1158,7 +1290,11 @@ img.thick-border {
   }
 
   .timeline-scroll-hint {
+    display: none;
     position: static;
+    right: auto;
+    bottom: auto;
+    left: auto;
     width: fit-content;
     margin: var(--sp-4) auto 0;
     transform: none;
@@ -1169,7 +1305,7 @@ img.thick-border {
   .timeline-inner {
     animation: timeline-pan 1ms linear both;
     animation-timeline: --projects-track;
-    animation-range: 25% 75%;
+    animation-range: 35.714% 64.286%;
   }
 }
 

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -959,6 +959,228 @@ img.thick-border {
   }
 }
 
+// Projects timeline: a tall track pins its viewport while the inner timeline
+// follows the page scroll. The cards are deliberately quiet and slightly
+// imperfect, like a working notebook rather than a product grid.
+.timeline {
+  max-width: 100%;
+  margin: 0;
+}
+
+.timeline-track {
+  position: relative;
+  height: 300vh;
+  view-timeline-name: --projects-track;
+  view-timeline-axis: block;
+}
+
+.timeline-pin {
+  position: sticky;
+  top: 0;
+  height: 100vh;
+  overflow: hidden;
+  outline: none;
+
+  &:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: -2px;
+  }
+}
+
+.timeline-inner {
+  position: relative;
+  height: 300vh;
+  min-height: 100%;
+}
+
+.timeline-rail {
+  position: absolute;
+  top: var(--sp-6);
+  right: 0;
+  bottom: calc(var(--sp-6) + var(--sp-8));
+  display: grid;
+  grid-template-rows: repeat(var(--timeline-items), minmax(0, 1fr));
+  width: 16%;
+  border-left: 1px solid var(--accent);
+}
+
+.timeline-tick {
+  position: relative;
+  display: flex;
+  align-items: center;
+  min-width: 0;
+}
+
+.timeline-tick::before {
+  content: "";
+  position: absolute;
+  left: calc(var(--sp-2) * -1);
+  width: var(--sp-3);
+  border-top: 1px solid var(--accent);
+}
+
+.timeline-tick-date {
+  margin-left: var(--sp-3);
+  color: var(--accent);
+  font-size: var(--fs-meta);
+  line-height: 1.2;
+  white-space: nowrap;
+}
+
+.timeline-cards {
+  position: absolute;
+  top: var(--sp-6);
+  right: calc(16% + var(--sp-4));
+  bottom: calc(var(--sp-6) + var(--sp-8));
+  left: 0;
+  display: grid;
+  grid-template-rows: repeat(var(--timeline-items), minmax(0, 1fr));
+}
+
+.timeline-card {
+  align-self: center;
+  box-sizing: border-box;
+  width: 100%;
+  max-width: 22rem;
+  padding: var(--sp-4);
+  overflow-wrap: anywhere;
+  border: 1px solid var(--rule-strong);
+  background-color: var(--bg);
+  background-image: repeating-linear-gradient(
+    135deg,
+    transparent 0 var(--sp-2),
+    var(--rule) var(--sp-2) calc(var(--sp-2) + 1px)
+  );
+}
+
+.timeline-card--left {
+  justify-self: start;
+  margin-left: var(--sp-4);
+  transform: rotate(-1.5deg);
+}
+
+.timeline-card--right {
+  justify-self: end;
+  margin-right: var(--sp-2);
+  transform: rotate(1.5deg);
+}
+
+.timeline-card-date {
+  margin: 0 0 var(--sp-2);
+  color: var(--muted);
+  font-size: var(--fs-meta);
+}
+
+.timeline-card-title {
+  margin: 0 0 var(--sp-2);
+  font-size: var(--fs-body);
+  line-height: 1.3;
+}
+
+.timeline-card-description,
+.timeline-card-link {
+  font-size: var(--fs-meta);
+  line-height: 1.5;
+
+  p {
+    margin: 0;
+  }
+}
+
+.timeline-card-link {
+  margin-top: var(--sp-3);
+}
+
+.timeline-scroll-hint {
+  position: absolute;
+  bottom: var(--sp-4);
+  left: 50%;
+  margin: 0;
+  padding: var(--sp-1) var(--sp-3);
+  transform: translateX(-50%);
+  color: var(--muted);
+  background: var(--bg);
+  border: 1px solid var(--rule);
+  font-size: var(--fs-label);
+  letter-spacing: var(--tracking-label);
+  white-space: nowrap;
+}
+
+@keyframes timeline-pan {
+  from {
+    transform: translateY(0);
+  }
+
+  to {
+    transform: translateY(calc(-100% + 100vh));
+  }
+}
+
+@mixin timeline-static {
+  .timeline-track {
+    height: auto;
+    view-timeline-name: none;
+  }
+
+  .timeline-pin {
+    position: static;
+    height: auto;
+    overflow: visible;
+  }
+
+  .timeline-inner {
+    height: auto;
+    min-height: 0;
+    padding-bottom: var(--sp-6);
+    animation: none;
+    transform: none;
+  }
+
+  .timeline-rail {
+    display: none;
+  }
+
+  .timeline-cards {
+    position: static;
+    display: grid;
+    grid-template-rows: none;
+    gap: var(--sp-5);
+  }
+
+  .timeline-card,
+  .timeline-card--left,
+  .timeline-card--right {
+    width: 100%;
+    max-width: none;
+    margin: 0;
+    transform: none;
+    justify-self: stretch;
+  }
+
+  .timeline-scroll-hint {
+    position: static;
+    width: fit-content;
+    margin: var(--sp-4) auto 0;
+    transform: none;
+  }
+}
+
+@supports (animation-timeline: scroll()) {
+  .timeline-inner {
+    animation: timeline-pan 1ms linear both;
+    animation-timeline: --projects-track;
+    animation-range: 25% 75%;
+  }
+}
+
+@supports not (animation-timeline: scroll()) {
+  @include timeline-static;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  @include timeline-static;
+}
+
 // Latest writing: title left, date right, hairline row separators.
 .writing {
   margin: 0;
@@ -1062,6 +1284,8 @@ img.thick-border {
     align-items: flex-start;
     gap: var(--sp-1);
   }
+
+  @include timeline-static;
 }
 
 // -------------- PRINT -------------- //

--- a/content/_index.md
+++ b/content/_index.md
@@ -29,15 +29,15 @@ Most of my time now goes to the AI side: LLMs, agents, and the tooling around
 them, from prompt to production. The security background is why I build those
 systems with security in mind, not as an afterthought.
 
-{{< sec "stack" >}}
+{{< sec "projects" >}}
 
-{{< rows >}}
-languages | Python · Java · TypeScript · SQL · Bash
-frameworks | Next.js · React Native · Flutter · Spring Boot
-infrastructure | Docker · Git · Linux/RHEL · CI/CD
-security | Defensive · Offensive · Pentesting · CTF
-ai | LLMs · agents · prompt to production
-{{< /rows >}}
+{{< timeline >}}
+pi-terminal-kit | Jul 16, 2026 | reusable Pi, tmux, Fish, and Ghostty pieces for visible agent work | [source](https://github.com/isaaclins/pi-terminal-kit)
+Spotiglass | May 3, 2026 | native macOS Spotify client in SwiftUI | [source](https://github.com/isaaclins/spotiglass)
+Home Server + LLM | TODO-DATE | self-hosted server with Ollama LLM integration, file uploads, and user management with JWT | [source](https://github.com/isaaclins/ollama-model-api)
+PowerUserMail | TODO-DATE | keyboard-first email client for macOS | [source](https://github.com/isaaclins/powerusermail)
+Restaurant Application | TODO-DATE | microservices system for online ordering with a customizable website, Kitchen Display System, and backend with SMTP control | [source](https://github.com/isaaclins/restaurant-application)
+{{< /timeline >}}
 
 {{< sec "writing" >}}
 

--- a/content/_index.md
+++ b/content/_index.md
@@ -32,11 +32,11 @@ systems with security in mind, not as an afterthought.
 {{< sec "projects" >}}
 
 {{< timeline >}}
-pi-terminal-kit | Jul 16, 2026 | reusable Pi, tmux, Fish, and Ghostty pieces for visible agent work | [source](https://github.com/isaaclins/pi-terminal-kit)
-Spotiglass | May 3, 2026 | native macOS Spotify client in SwiftUI | [source](https://github.com/isaaclins/spotiglass)
-Home Server + LLM | TODO-DATE | self-hosted server with Ollama LLM integration, file uploads, and user management with JWT | [source](https://github.com/isaaclins/ollama-model-api)
-PowerUserMail | TODO-DATE | keyboard-first email client for macOS | [source](https://github.com/isaaclins/powerusermail)
-Restaurant Application | TODO-DATE | microservices system for online ordering with a customizable website, Kitchen Display System, and backend with SMTP control | [source](https://github.com/isaaclins/restaurant-application)
+pi-terminal-kit | Jul 2026 | reusable Pi, tmux, Fish, and Ghostty pieces for visible agent work | [source](https://github.com/isaaclins/pi-terminal-kit) | pi-terminal-kit
+Spotiglass | Apr 2026 | native macOS Spotify client in SwiftUI | [source](https://github.com/isaaclins/spotiglass)
+Restaurant Application | Dec 2025 | microservices system for online ordering with a customizable website, Kitchen Display System, and backend with SMTP control | [source](https://github.com/isaaclins/restaurant-application)
+PowerUserMail | Nov 2025 | keyboard-first email client for macOS | [source](https://github.com/isaaclins/powerusermail)
+Home Server + LLM | May 2025 | self-hosted server with Ollama LLM integration, file uploads, and user management with JWT | [source](https://github.com/isaaclins/ollama-model-api)
 {{< /timeline >}}
 
 {{< sec "writing" >}}

--- a/content/projects/_index.md
+++ b/content/projects/_index.md
@@ -1,0 +1,11 @@
++++
+title = "Projects"
+date = 2026-08-04
+draft = false
+show_date = false
+description = "Things I have built: terminal tooling for AI agents, native macOS apps, self-hosted infrastructure, and a few systems that had to survive real users."
+outputs = ["HTML", "RSS"]
++++
+
+The long versions of the projects on the [home page](/). Not everything here
+has a write-up yet.

--- a/content/projects/pi-terminal-kit.md
+++ b/content/projects/pi-terminal-kit.md
@@ -1,0 +1,40 @@
++++
+title = "pi-terminal-kit"
+date = 2026-07-16
+draft = false
+show_date = false
+tags = ["Dev", "Pi", "Terminal"]
+description = "Portable terminal integrations for Pi: share the visible tmux pane with a child agent, bridge Fish functions safely, and theme the whole thing."
++++
+
+Agent work usually happens somewhere you cannot see. A process spawns, does
+something for two minutes, and hands you back a summary you have to take on
+faith. pi-terminal-kit exists because I wanted to watch it happen instead.
+
+It is a set of [portable terminal integrations for Pi](https://github.com/isaaclins/pi-terminal-kit),
+split into packages you can install one at a time rather than one framework you
+have to adopt whole.
+
+## The pieces
+
+**`pi-codrive`** shares the exact visible tmux pane with a child agent and gets
+an authenticated structured completion report back. You see the work as it
+happens, in the same pane you are already looking at, and you can steer it
+mid-run instead of waiting for it to finish being wrong.
+
+**`pi-fish-bridge`** exposes selected Fish functions to Pi shell commands. The
+important word is selected: you list what is allowed rather than handing over
+the whole shell.
+
+**`pi-arcoiris-refined`** is a complete 51 token dark theme, and the
+**ghostty-tmux-fish recipe** is the copy-pasteable version of the terminal
+setup, for when you want the result without reading the reasoning.
+
+## Why it is split up
+
+Each package is independently versioned and publishable. That is deliberate. A
+theme should not be able to break your agent tooling, and wanting the Fish
+bridge should not mean adopting somebody else's tmux config.
+
+The requirement across the board is Pi 0.80.3 or newer, Node 20 or 22, tmux,
+and macOS or Linux.

--- a/layouts/shortcodes/timeline.html
+++ b/layouts/shortcodes/timeline.html
@@ -1,4 +1,7 @@
-{{/* One project per line: title | date | description | markdown link. */}}
+{{/* One project per line:
+     title | date | short description | markdown link | optional project page slug
+     The fifth field is optional. When present the card gets a read more link
+     pointing at /projects/<slug>/, where the long version lives. */}}
 {{- $projects := slice -}}
 {{- range $line := split (trim .Inner "\n\r \t") "\n" -}}
   {{- $line = trim $line " \t\r" -}}
@@ -8,22 +11,71 @@
     {{- $date := "TODO-DATE" -}}
     {{- $description := "" -}}
     {{- $link := "" -}}
+    {{- $slug := "" -}}
     {{- if gt (len $parts) 1 }}{{ $date = trim (index $parts 1) " " }}{{ end -}}
     {{- if gt (len $parts) 2 }}{{ $description = trim (index $parts 2) " " }}{{ end -}}
-    {{- if gt (len $parts) 3 }}{{ $link = trim (delimit (after 3 $parts) "|") " " }}{{ end -}}
-    {{- $projects = $projects | append (dict "title" $title "date" $date "description" $description "link" $link) -}}
+    {{- if gt (len $parts) 3 }}{{ $link = trim (index $parts 3) " " }}{{ end -}}
+    {{- if gt (len $parts) 4 }}{{ $slug = trim (delimit (after 4 $parts) "|") " " }}{{ end -}}
+    {{- $projects = $projects | append (dict "title" $title "date" $date "description" $description "link" $link "slug" $slug) -}}
   {{- end -}}
 {{- end -}}
+{{- $rows := len $projects -}}
+{{- $steps := 1 -}}
+{{- if gt $rows 1 }}{{ $steps = sub $rows 1 }}{{ end -}}
 
-<section class="timeline" aria-labelledby="projects">
+{{/* The pinned stretch occupies a sub-range of the track's view timeline.
+     Values are stored in thousandths of a percentage so Hugo's integer math
+     can keep the ranges deterministic without adding a runtime dependency. */}}
+{{- $viewStartN := 33333 -}}
+{{- $viewEndN := 66667 -}}
+{{- if eq $steps 1 }}{{ $viewStartN = 45455 }}{{ $viewEndN = 54545 }}
+{{- else if eq $steps 2 }}{{ $viewStartN = 41667 }}{{ $viewEndN = 58333 }}
+{{- else if eq $steps 3 }}{{ $viewStartN = 38462 }}{{ $viewEndN = 61538 }}
+{{- else if eq $steps 4 }}{{ $viewStartN = 35714 }}{{ $viewEndN = 64286 }}
+{{- else if eq $steps 6 }}{{ $viewStartN = 31250 }}{{ $viewEndN = 68750 }}
+{{- else if eq $steps 7 }}{{ $viewStartN = 29412 }}{{ $viewEndN = 70588 }}
+{{- else if eq $steps 8 }}{{ $viewStartN = 27778 }}{{ $viewEndN = 72222 }}
+{{- else if eq $steps 9 }}{{ $viewStartN = 26316 }}{{ $viewEndN = 73684 }}
+{{- else if eq $steps 10 }}{{ $viewStartN = 25000 }}{{ $viewEndN = 75000 }}{{ end -}}
+{{- $viewSpanN := sub $viewEndN $viewStartN -}}
+{{- $viewStart := printf "%d.%03d%%" (div $viewStartN 1000) (mod $viewStartN 1000) -}}
+{{- $viewEnd := printf "%d.%03d%%" (div $viewEndN 1000) (mod $viewEndN 1000) -}}
+
+{{/* Windows hand over at the midpoint between neighbouring card centres. */}}
+{{- $centres2 := slice -}}
+{{- $cursor := 0 -}}
+{{- range $project := $projects -}}
+  {{- $span := 1 -}}
+  {{- with $project.body }}{{ $span = 2 }}{{ end -}}
+  {{- $centres2 = $centres2 | append (add (mul 2 $cursor) (sub $span 1)) -}}
+  {{- $cursor = add $cursor $span -}}
+{{- end -}}
+{{- $last := sub (len $projects) 1 -}}
+{{- $placed := slice -}}
+{{- range $index, $project := $projects -}}
+  {{- $fromN := $viewStartN -}}
+  {{- if gt $index 0 -}}
+    {{- $edge2 := add (index $centres2 (sub $index 1)) (index $centres2 $index) -}}
+    {{- $fromN = add $viewStartN (div (mul $edge2 $viewSpanN) (mul 4 $steps)) -}}
+  {{- end -}}
+  {{- $toN := $viewEndN -}}
+  {{- if lt $index $last -}}
+    {{- $edge2 := add (index $centres2 $index) (index $centres2 (add $index 1)) -}}
+    {{- $toN = add $viewStartN (div (mul $edge2 $viewSpanN) (mul 4 $steps)) -}}
+  {{- end -}}
+  {{- $from := printf "%d.%03d%%" (div $fromN 1000) (mod $fromN 1000) -}}
+  {{- $to := printf "%d.%03d%%" (div $toN 1000) (mod $toN 1000) -}}
+  {{- $placed = $placed | append (merge $project (dict "from" $from "to" $to)) -}}
+{{- end -}}
+{{- $projects = $placed -}}
+
+<section class="timeline" aria-labelledby="projects" style="--timeline-items: {{ len $projects }}; --timeline-rows: {{ $rows }}; --timeline-steps: {{ $steps }}; --timeline-view-start: {{ $viewStart | safeCSS }}; --timeline-view-end: {{ $viewEnd | safeCSS }};">
   <div class="timeline-track">
     <div class="timeline-pin" tabindex="0" aria-label="Projects timeline, scrollable">
-      <div class="timeline-inner" style="--timeline-items: {{ len $projects }};">
+      <div class="timeline-inner">
         <div class="timeline-rail" aria-hidden="true">
           {{- range $project := $projects -}}
-            <span class="timeline-tick">
-              <span class="timeline-tick-date">{{ $project.date }}</span>
-            </span>
+            <span class="timeline-tick"></span>
           {{- end -}}
         </div>
 
@@ -35,14 +87,25 @@
               {{- with $project.description }}
                 <div class="timeline-card-description">{{ . | markdownify }}</div>
               {{- end -}}
-              {{- with $project.link }}
-                <div class="timeline-card-link">{{ . | markdownify }}</div>
-              {{- end -}}
+              <div class="timeline-card-links">
+                {{- with $project.slug }}
+                  <a class="timeline-card-more" href="{{ printf "/projects/%s/" . | relURL }}">read more &rarr;</a>
+                {{- end -}}
+                {{- with $project.link }}{{ . | markdownify }}{{ end -}}
+              </div>
             </article>
           {{- end -}}
         </div>
 
       </div>
+      {{/* Outside the scrolling layer, so it can hold the middle slot. Only the
+           project currently being read shows its date here. */}}
+      <div class="timeline-dates" aria-hidden="true">
+        {{- range $index, $project := $projects -}}
+          <span class="timeline-date{{ if eq $index 0 }} timeline-date--first{{ end }}{{ if eq $index $last }} timeline-date--last{{ end }}" style="--from: {{ $project.from | safeCSS }}; --to: {{ $project.to | safeCSS }};">{{ $project.date }}</span>
+        {{- end -}}
+      </div>
+
       <span class="timeline-scroll-hint" aria-hidden="true">scroll to explore</span>
     </div>
   </div>

--- a/layouts/shortcodes/timeline.html
+++ b/layouts/shortcodes/timeline.html
@@ -1,0 +1,49 @@
+{{/* One project per line: title | date | description | markdown link. */}}
+{{- $projects := slice -}}
+{{- range $line := split (trim .Inner "\n\r \t") "\n" -}}
+  {{- $line = trim $line " \t\r" -}}
+  {{- if $line -}}
+    {{- $parts := split $line "|" -}}
+    {{- $title := trim (index $parts 0) " " -}}
+    {{- $date := "TODO-DATE" -}}
+    {{- $description := "" -}}
+    {{- $link := "" -}}
+    {{- if gt (len $parts) 1 }}{{ $date = trim (index $parts 1) " " }}{{ end -}}
+    {{- if gt (len $parts) 2 }}{{ $description = trim (index $parts 2) " " }}{{ end -}}
+    {{- if gt (len $parts) 3 }}{{ $link = trim (delimit (after 3 $parts) "|") " " }}{{ end -}}
+    {{- $projects = $projects | append (dict "title" $title "date" $date "description" $description "link" $link) -}}
+  {{- end -}}
+{{- end -}}
+
+<section class="timeline" aria-labelledby="projects">
+  <div class="timeline-track">
+    <div class="timeline-pin" tabindex="0" aria-label="Projects timeline, scrollable">
+      <div class="timeline-inner" style="--timeline-items: {{ len $projects }};">
+        <div class="timeline-rail" aria-hidden="true">
+          {{- range $project := $projects -}}
+            <span class="timeline-tick">
+              <span class="timeline-tick-date">{{ $project.date }}</span>
+            </span>
+          {{- end -}}
+        </div>
+
+        <div class="timeline-cards">
+          {{- range $index, $project := $projects -}}
+            <article class="timeline-card timeline-card--{{ if eq (mod $index 2) 0 }}left{{ else }}right{{ end }}">
+              <p class="timeline-card-date">{{ $project.date }}</p>
+              <h3 class="timeline-card-title">{{ $project.title }}</h3>
+              {{- with $project.description }}
+                <div class="timeline-card-description">{{ . | markdownify }}</div>
+              {{- end -}}
+              {{- with $project.link }}
+                <div class="timeline-card-link">{{ . | markdownify }}</div>
+              {{- end -}}
+            </article>
+          {{- end -}}
+        </div>
+
+      </div>
+      <span class="timeline-scroll-hint" aria-hidden="true">scroll to explore</span>
+    </div>
+  </div>
+</section>


### PR DESCRIPTION
Closes #52. Replaces the homepage `stack` table with a projects timeline.

**Stack:** built on top of #59, which is already merged, so this targets `main` directly.

### What it does

The section pins to the viewport on a tall runway and the cards advance with CSS scroll-driven animation, so scrolling walks the timeline and then releases into `writing`. A single date label parks at the middle right of the rail and hands over to the next at the midpoint between neighbouring cards, so exactly one date is on screen at any moment and it always names the card you are looking at.

No JavaScript. No new dependencies. No new fonts.

### Authoring

One project per line, fifth field optional:

```
title | date | short description | markdown link | optional project page slug
```

The fifth field renders a `read more` link to `/projects/<slug>/`, where the long version lives. New `content/projects/` section, with `pi-terminal-kit` as the first write-up.

### Data

All five dates are GitHub repository creation dates, applied as one uniform rule rather than mixing sources. Nothing invented.

| Project | Date |
|---|---|
| pi-terminal-kit | Jul 2026 |
| Spotiglass | Apr 2026 |
| Restaurant Application | Dec 2025 |
| PowerUserMail | Nov 2025 |
| Home Server + LLM | May 2025 |

### Fallbacks

All three degrade to a plain readable vertical list with no pinning and no floating date, since every card already prints its own date:

- `@supports not (animation-timeline: scroll())`, for Firefox
- `prefers-reduced-motion: reduce`
- the 640px breakpoint

### Verified

- `hugo --gc --minify`: zero errors, zero warnings.
- Pinned run screenshotted at six scroll offsets. One date visible at each, matching the centred card.
- No horizontal overflow: 1440 `1425/1425`, 768 `753/753`, 390 `375/375`.
- `/projects/pi-terminal-kit/` and `/projects/` render with nav, correct measure, no stray date.
- Light and dark appearance both checked, `config.toml` restored exactly.

### Known nits, not blocking

- The parked date sits at the vertical centre of the viewport, so it does not line up with a rail tick. That follows from "sticky in the middle right of the screen" and is deliberate, but it is a look worth a second opinion.
- The breadcrumb renders the project title as "Pi terminal kit" rather than "pi-terminal-kit".
