### PR TITLE
Fix projects timeline entry and exit spacing

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -974,10 +974,12 @@ img.thick-border {
 // neighbour. The runway is derived from that row count rather than hardcoded,
 // so adding a project or a long body cannot silently break the spacing.
 .timeline {
-  --timeline-step: 20vh;
-  --timeline-travel: calc(var(--timeline-step) * var(--timeline-steps));
-  --timeline-rail-top: calc(50vh - (var(--timeline-step) / 2));
-  --timeline-length: calc(100vh + var(--timeline-travel));
+  --timeline-card-height: max(100vh, calc(var(--timeline-step) * var(--timeline-rows)));
+  --timeline-content-height: calc(
+    var(--timeline-card-height) + var(--timeline-edge) + var(--timeline-edge)
+  );
+  --timeline-travel: calc(var(--timeline-content-height) - 100vh);
+  --timeline-length: var(--timeline-content-height);
 }
 
 .timeline-track {
@@ -1016,13 +1018,13 @@ img.thick-border {
 
 .timeline-rail {
   position: absolute;
-  top: var(--timeline-rail-top);
+  top: var(--timeline-edge);
   right: 0;
   bottom: auto;
   display: grid;
   grid-template-rows: repeat(var(--timeline-rows), minmax(0, 1fr));
   width: 28%;
-  height: calc(var(--timeline-step) * var(--timeline-rows));
+  height: var(--timeline-card-height);
   border-left: 1px solid var(--accent);
 }
 
@@ -1070,14 +1072,22 @@ img.thick-border {
   animation-range: var(--from) var(--to);
 }
 
-// The first project already owns the slot when the pin engages.
-.timeline-date--first {
-  animation-name: timeline-date-first;
-  animation-range: calc(var(--from) - 0.1%) var(--to);
+.timeline-date--inactive {
+  display: none;
 }
 
-.timeline-date--last {
+.timeline-date--range-start {
+  animation-name: timeline-date-first;
+}
+
+.timeline-date--range-end {
   animation-name: timeline-date-last;
+  animation-range: var(--from) calc(var(--to) + 0.1%);
+}
+
+.timeline-date--range-hold {
+  animation-name: timeline-date-hold;
+  animation-range: var(--from) calc(var(--to) + 0.1%);
 }
 
 @keyframes timeline-date-first {
@@ -1116,15 +1126,23 @@ img.thick-border {
   }
 }
 
+@keyframes timeline-date-hold {
+  0%,
+  100% {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
 .timeline-cards {
   position: absolute;
-  top: var(--timeline-rail-top);
+  top: var(--timeline-edge);
   right: calc(28% + var(--sp-4));
   bottom: auto;
   left: 0;
   display: grid;
   grid-template-rows: repeat(var(--timeline-rows), minmax(0, 1fr));
-  height: calc(var(--timeline-step) * var(--timeline-rows));
+  height: var(--timeline-card-height);
 }
 
 .timeline-card {
@@ -1141,6 +1159,18 @@ img.thick-border {
     transparent 0 var(--sp-2),
     var(--rule) var(--sp-2) calc(var(--sp-2) + 1px)
   );
+}
+
+.timeline-card:first-child {
+  align-self: start;
+}
+
+.timeline-card:last-child {
+  align-self: end;
+}
+
+.timeline-card:only-child {
+  align-self: center;
 }
 
 .timeline-card--left {
@@ -1217,7 +1247,7 @@ img.thick-border {
   white-space: nowrap;
   animation: timeline-hint-fade linear both;
   animation-timeline: --projects-track;
-  animation-range: var(--timeline-view-start) calc(var(--timeline-view-start) + 6%);
+  animation-range: var(--timeline-view-start) var(--timeline-view-end);
 }
 
 @keyframes timeline-hint-fade {
@@ -1236,7 +1266,7 @@ img.thick-border {
   }
 
   to {
-    transform: translateY(calc(-100% + 100vh));
+    transform: translateY(calc(100vh - var(--timeline-length)));
   }
 }
 
@@ -1287,6 +1317,7 @@ img.thick-border {
     margin: 0;
     transform: none;
     justify-self: stretch;
+    align-self: stretch;
   }
 
   .timeline-scroll-hint {
@@ -1305,7 +1336,7 @@ img.thick-border {
   .timeline-inner {
     animation: timeline-pan 1ms linear both;
     animation-timeline: --projects-track;
-    animation-range: 35.714% 64.286%;
+    animation-range: var(--timeline-view-start) var(--timeline-view-end);
   }
 }
 

--- a/layouts/shortcodes/timeline.html
+++ b/layouts/shortcodes/timeline.html
@@ -23,53 +23,57 @@
 {{- $steps := 1 -}}
 {{- if gt $rows 1 }}{{ $steps = sub $rows 1 }}{{ end -}}
 
+{{/* The cards occupy a real content block with a small viewport-relative
+     gutter at either end. The viewport-relative gutter keeps the pinned range
+     and the CSS view-timeline percentages deterministic at every height. */}}
+{{- $stepVh := 20 -}}
+{{- $contentVh := mul $rows $stepVh -}}
+{{- if lt $contentVh 100 }}{{ $contentVh = 100 }}{{ end -}}
+{{- $edgeVh := 4 -}}
+{{- $timelineHeightVh := add $contentVh (mul 2 $edgeVh) -}}
+{{- $viewTotalVh := add $timelineHeightVh 100 -}}
+
 {{/* The pinned stretch occupies a sub-range of the track's view timeline.
      Values are stored in thousandths of a percentage so Hugo's integer math
      can keep the ranges deterministic without adding a runtime dependency. */}}
-{{- $viewStartN := 33333 -}}
-{{- $viewEndN := 66667 -}}
-{{- if eq $steps 1 }}{{ $viewStartN = 45455 }}{{ $viewEndN = 54545 }}
-{{- else if eq $steps 2 }}{{ $viewStartN = 41667 }}{{ $viewEndN = 58333 }}
-{{- else if eq $steps 3 }}{{ $viewStartN = 38462 }}{{ $viewEndN = 61538 }}
-{{- else if eq $steps 4 }}{{ $viewStartN = 35714 }}{{ $viewEndN = 64286 }}
-{{- else if eq $steps 6 }}{{ $viewStartN = 31250 }}{{ $viewEndN = 68750 }}
-{{- else if eq $steps 7 }}{{ $viewStartN = 29412 }}{{ $viewEndN = 70588 }}
-{{- else if eq $steps 8 }}{{ $viewStartN = 27778 }}{{ $viewEndN = 72222 }}
-{{- else if eq $steps 9 }}{{ $viewStartN = 26316 }}{{ $viewEndN = 73684 }}
-{{- else if eq $steps 10 }}{{ $viewStartN = 25000 }}{{ $viewEndN = 75000 }}{{ end -}}
+{{- $viewStartN := div 10000000 $viewTotalVh -}}
+{{- $viewEndN := div (mul $timelineHeightVh 100000) $viewTotalVh -}}
 {{- $viewSpanN := sub $viewEndN $viewStartN -}}
 {{- $viewStart := printf "%d.%03d%%" (div $viewStartN 1000) (mod $viewStartN 1000) -}}
 {{- $viewEnd := printf "%d.%03d%%" (div $viewEndN 1000) (mod $viewEndN 1000) -}}
 
-{{/* Windows hand over at the midpoint between neighbouring card centres. */}}
-{{- $centres2 := slice -}}
-{{- $cursor := 0 -}}
-{{- range $project := $projects -}}
-  {{- $span := 1 -}}
-  {{- with $project.body }}{{ $span = 2 }}{{ end -}}
-  {{- $centres2 = $centres2 | append (add (mul 2 $cursor) (sub $span 1)) -}}
-  {{- $cursor = add $cursor $span -}}
-{{- end -}}
+{{/* A handover belongs at the midpoint between neighbouring card centres.
+     Clamp centres outside the pinned range to its edge. This keeps the date
+     windows adjacent even when a short content block needs only its end
+     gutter as travel. */}}
+{{- $rowCount := $rows -}}
+{{- if lt $rowCount 1 }}{{ $rowCount = 1 }}{{ end -}}
+{{- $travelVh := sub $timelineHeightVh 100 -}}
+{{- $travelDenom := mul $travelVh $rowCount -}}
 {{- $last := sub (len $projects) 1 -}}
 {{- $placed := slice -}}
 {{- range $index, $project := $projects -}}
   {{- $fromN := $viewStartN -}}
   {{- if gt $index 0 -}}
-    {{- $edge2 := add (index $centres2 (sub $index 1)) (index $centres2 $index) -}}
-    {{- $fromN = add $viewStartN (div (mul $edge2 $viewSpanN) (mul 4 $steps)) -}}
+    {{- $boundary := sub (add (mul $edgeVh $rowCount) (mul $index $contentVh)) (mul 50 $rowCount) -}}
+    {{- if lt $boundary 0 }}{{ $boundary = 0 }}{{ end -}}
+    {{- if gt $boundary $travelDenom }}{{ $boundary = $travelDenom }}{{ end -}}
+    {{- $fromN = add $viewStartN (div (mul $boundary $viewSpanN) $travelDenom) -}}
   {{- end -}}
   {{- $toN := $viewEndN -}}
   {{- if lt $index $last -}}
-    {{- $edge2 := add (index $centres2 $index) (index $centres2 (add $index 1)) -}}
-    {{- $toN = add $viewStartN (div (mul $edge2 $viewSpanN) (mul 4 $steps)) -}}
+    {{- $boundary := sub (add (mul $edgeVh $rowCount) (mul (add $index 1) $contentVh)) (mul 50 $rowCount) -}}
+    {{- if lt $boundary 0 }}{{ $boundary = 0 }}{{ end -}}
+    {{- if gt $boundary $travelDenom }}{{ $boundary = $travelDenom }}{{ end -}}
+    {{- $toN = add $viewStartN (div (mul $boundary $viewSpanN) $travelDenom) -}}
   {{- end -}}
   {{- $from := printf "%d.%03d%%" (div $fromN 1000) (mod $fromN 1000) -}}
   {{- $to := printf "%d.%03d%%" (div $toN 1000) (mod $toN 1000) -}}
-  {{- $placed = $placed | append (merge $project (dict "from" $from "to" $to)) -}}
+  {{- $placed = $placed | append (merge $project (dict "from" $from "to" $to "fromN" $fromN "toN" $toN)) -}}
 {{- end -}}
 {{- $projects = $placed -}}
 
-<section class="timeline" aria-labelledby="projects" style="--timeline-items: {{ len $projects }}; --timeline-rows: {{ $rows }}; --timeline-steps: {{ $steps }}; --timeline-view-start: {{ $viewStart | safeCSS }}; --timeline-view-end: {{ $viewEnd | safeCSS }};">
+<section class="timeline" aria-labelledby="projects" style="--timeline-items: {{ len $projects }}; --timeline-rows: {{ $rows }}; --timeline-steps: {{ $steps }}; --timeline-step: {{ $stepVh }}vh; --timeline-edge: {{ $edgeVh }}vh; --timeline-view-start: {{ $viewStart | safeCSS }}; --timeline-view-end: {{ $viewEnd | safeCSS }};">
   <div class="timeline-track">
     <div class="timeline-pin" tabindex="0" aria-label="Projects timeline, scrollable">
       <div class="timeline-inner">
@@ -102,7 +106,7 @@
            project currently being read shows its date here. */}}
       <div class="timeline-dates" aria-hidden="true">
         {{- range $index, $project := $projects -}}
-          <span class="timeline-date{{ if eq $index 0 }} timeline-date--first{{ end }}{{ if eq $index $last }} timeline-date--last{{ end }}" style="--from: {{ $project.from | safeCSS }}; --to: {{ $project.to | safeCSS }};">{{ $project.date }}</span>
+          <span class="timeline-date{{ if eq $project.fromN $project.toN }} timeline-date--inactive{{ else }}{{ if eq $project.fromN $viewStartN }} timeline-date--range-start{{ end }}{{ if eq $project.toN $viewEndN }} timeline-date--range-end{{ end }}{{ if and (eq $project.fromN $viewStartN) (eq $project.toN $viewEndN) }} timeline-date--range-hold{{ end }}{{ end }}" style="--from: {{ $project.from | safeCSS }}; --to: {{ $project.to | safeCSS }};">{{ $project.date }}</span>
         {{- end -}}
       </div>
 


### PR DESCRIPTION
## What changed

- Start the pinned project content with the first card at the top gutter and finish with the last card at the bottom gutter.
- Derive travel from total content height minus the 100vh pin height.
- Recompute date windows from the card centre crossings, keeping one centred date visible at a time.
- Keep the no-animation, reduced-motion, and narrow-screen fallbacks as a readable vertical list.

## Verification

- `hugo --gc --minify` passes with zero errors and zero warnings.
- Headless 1440px probe screenshots cover the approach, pin start, mid-run, pin end, and release into WRITING.
- Headless checks cover 1440, 768, and 390px widths plus reduced motion.
- Light appearance was checked and config.toml was restored exactly.
