### PR TITLE
Remove the pin: the timeline scrolls normally and the date stays centred

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -959,73 +959,63 @@ img.thick-border {
   }
 }
 
-// Projects timeline: a tall track pins its viewport while the inner timeline
-// follows the page scroll. The cards are deliberately quiet and slightly
-// imperfect, like a working notebook rather than a product grid.
+// Projects timeline: a plain vertical list that scrolls with the page. One
+// date parks in the middle of the rail and names whichever card is crossing
+// the centre of the screen, so this reads like a rail you walk down rather
+// than a section that hijacks the scroll.
 .timeline {
+  --timeline-height: calc(var(--timeline-step) * var(--timeline-rows));
+
+  position: relative;
+  box-sizing: border-box;
   width: 100%;
   max-width: var(--measure);
   margin: 0 auto;
-  box-sizing: border-box;
-}
-
-// One row per project, plus an extra row for any project carrying the long
-// showcase text, so a tall card gets the space instead of colliding with its
-// neighbour. The runway is derived from that row count rather than hardcoded,
-// so adding a project or a long body cannot silently break the spacing.
-.timeline {
-  --timeline-card-height: max(100vh, calc(var(--timeline-step) * var(--timeline-rows)));
-  --timeline-content-height: calc(
-    var(--timeline-card-height) + var(--timeline-edge) + var(--timeline-edge)
-  );
-  --timeline-travel: calc(var(--timeline-content-height) - 100vh);
-  --timeline-length: var(--timeline-content-height);
-}
-
-.timeline-track {
-  position: relative;
-  width: 100%;
-  max-width: var(--measure);
-  height: var(--timeline-length);
-  margin-inline: auto;
-  box-sizing: border-box;
   view-timeline-name: --projects-track;
   view-timeline-axis: block;
 }
 
-.timeline-pin {
+// No height, and first in the DOM, so it can hold the middle of the viewport
+// for the whole section without pushing a single card out of place.
+.timeline-dates {
   position: sticky;
-  top: 0;
-  width: 100%;
-  max-width: var(--measure);
-  height: 100vh;
-  margin-inline: auto;
-  overflow: hidden;
-  box-sizing: border-box;
-  outline: none;
+  top: calc(50vh - 0.6em);
+  z-index: 1;
+  width: 28%;
+  height: 0;
+  margin-left: auto;
+  pointer-events: none;
+}
 
-  &:focus-visible {
-    outline: 2px solid var(--accent);
-    outline-offset: -2px;
-  }
+// Every label shares one slot. Each is painted only for the stretch where its
+// own card owns the centre line, and the stretches are adjacent, so exactly
+// one date is ever on screen.
+.timeline-date {
+  position: absolute;
+  top: 0;
+  left: 0;
+  margin-left: var(--sp-3);
+  color: var(--accent);
+  font-size: var(--fs-meta);
+  line-height: 1.2;
+  white-space: nowrap;
+  opacity: 0;
 }
 
 .timeline-inner {
   position: relative;
-  height: var(--timeline-length);
-  min-height: 100%;
 }
 
 .timeline-rail {
   position: absolute;
-  top: var(--timeline-edge);
+  top: 0;
   right: 0;
-  bottom: auto;
   display: grid;
   grid-template-rows: repeat(var(--timeline-rows), minmax(0, 1fr));
   width: 28%;
-  height: var(--timeline-card-height);
+  height: var(--timeline-height);
   border-left: 1px solid var(--accent);
+  pointer-events: none;
 }
 
 .timeline-tick {
@@ -1043,106 +1033,14 @@ img.thick-border {
   border-top: 1px solid var(--accent);
 }
 
-// A single date owns the middle of the rail. It lives outside the scrolling
-// layer, so it holds position while the cards travel past underneath. Each
-// label is visible only for the stretch where its own card is the one being
-// read, and the windows are adjacent rather than overlapping, so exactly one
-// date is ever on screen.
-.timeline-dates {
-  position: absolute;
-  top: 50%;
-  right: 0;
-  width: 28%;
-  height: 0;
-  pointer-events: none;
-}
-
-.timeline-date {
-  position: absolute;
-  top: -0.6em;
-  left: 0;
-  margin-left: var(--sp-3);
-  color: var(--accent);
-  font-size: var(--fs-meta);
-  line-height: 1.2;
-  white-space: nowrap;
-  opacity: 0;
-  animation: timeline-date-cycle linear;
-  animation-timeline: --projects-track;
-  animation-range: var(--from) var(--to);
-}
-
-.timeline-date--inactive {
-  display: none;
-}
-
-.timeline-date--range-start {
-  animation-name: timeline-date-first;
-}
-
-.timeline-date--range-end {
-  animation-name: timeline-date-last;
-  animation-range: var(--from) calc(var(--to) + 0.1%);
-}
-
-.timeline-date--range-hold {
-  animation-name: timeline-date-hold;
-  animation-range: var(--from) calc(var(--to) + 0.1%);
-}
-
-@keyframes timeline-date-first {
-  0%,
-  86% {
-    opacity: 1;
-    transform: translateY(0);
-  }
-
-  100% {
-    opacity: 0;
-    transform: translateY(-1.4em);
-  }
-}
-
-// The middle labels switch at their range boundary, so one label remains
-// visible even on the exact handover frame.
-@keyframes timeline-date-cycle {
-  0%,
-  86% {
-    opacity: 1;
-    transform: translateY(0);
-  }
-
-  100% {
-    opacity: 0;
-    transform: translateY(-1.4em);
-  }
-}
-
-@keyframes timeline-date-last {
-  0%,
-  100% {
-    opacity: 1;
-    transform: translateY(0);
-  }
-}
-
-@keyframes timeline-date-hold {
-  0%,
-  100% {
-    opacity: 1;
-    transform: translateY(0);
-  }
-}
-
+// One equal row per project, so a tick, a card and a date all describe the
+// same slice of the page.
 .timeline-cards {
-  position: absolute;
-  top: var(--timeline-edge);
-  right: calc(28% + var(--sp-4));
-  bottom: auto;
-  left: 0;
+  box-sizing: border-box;
   display: grid;
   grid-template-rows: repeat(var(--timeline-rows), minmax(0, 1fr));
-  height: var(--timeline-card-height);
+  height: var(--timeline-height);
+  padding-right: calc(28% + var(--sp-4));
 }
 
 .timeline-card {
@@ -1159,18 +1057,6 @@ img.thick-border {
     transparent 0 var(--sp-2),
     var(--rule) var(--sp-2) calc(var(--sp-2) + 1px)
   );
-}
-
-.timeline-card:first-child {
-  align-self: start;
-}
-
-.timeline-card:last-child {
-  align-self: end;
-}
-
-.timeline-card:only-child {
-  align-self: center;
 }
 
 .timeline-card--left {
@@ -1198,8 +1084,7 @@ img.thick-border {
   line-height: 1.2;
 }
 
-.timeline-card-description,
-.timeline-card-links {
+.timeline-card-description {
   font-size: var(--fs-meta);
   line-height: 1.45;
 
@@ -1227,116 +1112,59 @@ img.thick-border {
   white-space: nowrap;
 }
 
-// Bottom right, inside the rail gutter. The cards stop before this column, so
-// the hint never sits on top of card content.
-// Only useful before you have started. It fades out over the first stretch of
-// the pin so it stops competing with the cards.
-.timeline-scroll-hint {
-  position: absolute;
-  right: 0;
-  bottom: var(--sp-2);
-  left: auto;
-  margin: 0;
-  padding: var(--sp-1) var(--sp-3);
-  transform: none;
-  color: var(--muted);
-  background: var(--bg);
-  border: 1px solid var(--rule);
-  font-size: var(--fs-label);
-  letter-spacing: var(--tracking-label);
-  white-space: nowrap;
-  animation: timeline-hint-fade linear both;
-  animation-timeline: --projects-track;
-  animation-range: var(--timeline-view-start) var(--timeline-view-end);
-}
-
-@keyframes timeline-hint-fade {
-  0% {
+@keyframes timeline-date-show {
+  from,
+  to {
     opacity: 1;
   }
+}
 
-  100% {
-    opacity: 0;
+// Outside its range the animation simply does not apply, which leaves the
+// label on its base opacity of zero. That is what keeps the handover clean
+// without a second keyframe doing the hiding.
+@supports (animation-timeline: scroll()) {
+  .timeline-date {
+    animation: timeline-date-show 1ms linear;
+    animation-timeline: --projects-track;
+    animation-range: var(--from) var(--to);
   }
 }
 
-@keyframes timeline-pan {
-  from {
-    transform: translateY(0);
-  }
-
-  to {
-    transform: translateY(calc(100vh - var(--timeline-length)));
-  }
-}
-
+// Without scroll-driven animation there is no way to know which card owns the
+// centre. Every card already prints its own date, so the floating label is the
+// only thing that has to go. The rail and the cards are static layout and
+// survive intact.
 @mixin timeline-static {
-  .timeline-track {
-    height: auto;
-    view-timeline-name: none;
-  }
-
-  .timeline-pin {
-    position: static;
-    height: auto;
-    overflow: visible;
-  }
-
-  .timeline-inner {
-    height: auto;
-    min-height: 0;
-    padding-bottom: var(--sp-6);
-    animation: none;
-    transform: none;
-  }
-
-  // No pinning means no middle slot to park in. The cards already print their
-  // dates, so the rail and floating labels are noise in the static layout.
-  .timeline-rail,
   .timeline-dates {
+    display: none;
+  }
+}
+
+// Narrow screens have no room for a rail beside the cards, so the timeline
+// becomes an ordinary stack.
+@mixin timeline-plain {
+  @include timeline-static;
+
+  .timeline-rail {
     display: none;
   }
 
   .timeline-cards {
-    position: static;
-    top: auto;
-    right: auto;
-    bottom: auto;
-    left: auto;
     display: grid;
     grid-template-rows: none;
-    height: auto;
+    grid-auto-rows: auto;
     gap: var(--sp-5);
+    height: auto;
+    padding-right: 0;
   }
 
   .timeline-card,
   .timeline-card--left,
   .timeline-card--right {
-    width: 100%;
     max-width: none;
     margin: 0;
     transform: none;
     justify-self: stretch;
-    align-self: stretch;
-  }
-
-  .timeline-scroll-hint {
-    display: none;
-    position: static;
-    right: auto;
-    bottom: auto;
-    left: auto;
-    width: fit-content;
-    margin: var(--sp-4) auto 0;
-    transform: none;
-  }
-}
-
-@supports (animation-timeline: scroll()) {
-  .timeline-inner {
-    animation: timeline-pan 1ms linear both;
-    animation-timeline: --projects-track;
-    animation-range: var(--timeline-view-start) var(--timeline-view-end);
   }
 }
 
@@ -1452,7 +1280,7 @@ img.thick-border {
     gap: var(--sp-1);
   }
 
-  @include timeline-static;
+  @include timeline-plain;
 }
 
 // -------------- PRINT -------------- //

--- a/layouts/shortcodes/timeline.html
+++ b/layouts/shortcodes/timeline.html
@@ -20,97 +20,65 @@
   {{- end -}}
 {{- end -}}
 {{- $rows := len $projects -}}
-{{- $steps := 1 -}}
-{{- if gt $rows 1 }}{{ $steps = sub $rows 1 }}{{ end -}}
 
-{{/* The cards occupy a real content block with a small viewport-relative
-     gutter at either end. The viewport-relative gutter keeps the pinned range
-     and the CSS view-timeline percentages deterministic at every height. */}}
-{{- $stepVh := 20 -}}
-{{- $contentVh := mul $rows $stepVh -}}
-{{- if lt $contentVh 100 }}{{ $contentVh = 100 }}{{ end -}}
-{{- $edgeVh := 4 -}}
-{{- $timelineHeightVh := add $contentVh (mul 2 $edgeVh) -}}
-{{- $viewTotalVh := add $timelineHeightVh 100 -}}
+{{/* Each project owns one row of the same height, so a tick, a card and a
+     date all describe the same slice of the page. The section is taller than
+     the viewport, which is what gives the sticky date something to hold. */}}
+{{- $stepVh := 26 -}}
+{{- $heightVh := mul $rows $stepVh -}}
 
-{{/* The pinned stretch occupies a sub-range of the track's view timeline.
-     Values are stored in thousandths of a percentage so Hugo's integer math
-     can keep the ranges deterministic without adding a runtime dependency. */}}
-{{- $viewStartN := div 10000000 $viewTotalVh -}}
-{{- $viewEndN := div (mul $timelineHeightVh 100000) $viewTotalVh -}}
-{{- $viewSpanN := sub $viewEndN $viewStartN -}}
-{{- $viewStart := printf "%d.%03d%%" (div $viewStartN 1000) (mod $viewStartN 1000) -}}
-{{- $viewEnd := printf "%d.%03d%%" (div $viewEndN 1000) (mod $viewEndN 1000) -}}
+{{/* The section carries a view timeline, so progress runs from the moment its
+     top enters the bottom of the viewport to the moment its bottom leaves the
+     top, a span of (height + 100vh). A point y inside the section sits on the
+     centre line at progress (y + 50) / (height + 100). Row boundaries put
+     through that gives each date the exact stretch where its own card is the
+     one crossing the middle of the screen.
 
-{{/* A handover belongs at the midpoint between neighbouring card centres.
-     Clamp centres outside the pinned range to its edge. This keeps the date
-     windows adjacent even when a short content block needs only its end
-     gutter as travel. */}}
-{{- $rowCount := $rows -}}
-{{- if lt $rowCount 1 }}{{ $rowCount = 1 }}{{ end -}}
-{{- $travelVh := sub $timelineHeightVh 100 -}}
-{{- $travelDenom := mul $travelVh $rowCount -}}
-{{- $last := sub (len $projects) 1 -}}
+     Values are kept in thousandths of a percent so Hugo's integer maths stays
+     exact and the windows tile with no gap and no overlap. */}}
+{{- $spanVh := add $heightVh 100 -}}
 {{- $placed := slice -}}
 {{- range $index, $project := $projects -}}
-  {{- $fromN := $viewStartN -}}
-  {{- if gt $index 0 -}}
-    {{- $boundary := sub (add (mul $edgeVh $rowCount) (mul $index $contentVh)) (mul 50 $rowCount) -}}
-    {{- if lt $boundary 0 }}{{ $boundary = 0 }}{{ end -}}
-    {{- if gt $boundary $travelDenom }}{{ $boundary = $travelDenom }}{{ end -}}
-    {{- $fromN = add $viewStartN (div (mul $boundary $viewSpanN) $travelDenom) -}}
-  {{- end -}}
-  {{- $toN := $viewEndN -}}
-  {{- if lt $index $last -}}
-    {{- $boundary := sub (add (mul $edgeVh $rowCount) (mul (add $index 1) $contentVh)) (mul 50 $rowCount) -}}
-    {{- if lt $boundary 0 }}{{ $boundary = 0 }}{{ end -}}
-    {{- if gt $boundary $travelDenom }}{{ $boundary = $travelDenom }}{{ end -}}
-    {{- $toN = add $viewStartN (div (mul $boundary $viewSpanN) $travelDenom) -}}
-  {{- end -}}
+  {{- $fromN := div (mul (add (mul $index $stepVh) 50) 100000) $spanVh -}}
+  {{- $toN := div (mul (add (mul (add $index 1) $stepVh) 50) 100000) $spanVh -}}
   {{- $from := printf "%d.%03d%%" (div $fromN 1000) (mod $fromN 1000) -}}
   {{- $to := printf "%d.%03d%%" (div $toN 1000) (mod $toN 1000) -}}
-  {{- $placed = $placed | append (merge $project (dict "from" $from "to" $to "fromN" $fromN "toN" $toN)) -}}
+  {{- $placed = $placed | append (merge $project (dict "from" $from "to" $to)) -}}
 {{- end -}}
 {{- $projects = $placed -}}
 
-<section class="timeline" aria-labelledby="projects" style="--timeline-items: {{ len $projects }}; --timeline-rows: {{ $rows }}; --timeline-steps: {{ $steps }}; --timeline-step: {{ $stepVh }}vh; --timeline-edge: {{ $edgeVh }}vh; --timeline-view-start: {{ $viewStart | safeCSS }}; --timeline-view-end: {{ $viewEnd | safeCSS }};">
-  <div class="timeline-track">
-    <div class="timeline-pin" tabindex="0" aria-label="Projects timeline, scrollable">
-      <div class="timeline-inner">
-        <div class="timeline-rail" aria-hidden="true">
-          {{- range $project := $projects -}}
-            <span class="timeline-tick"></span>
+<section class="timeline" aria-labelledby="projects" style="--timeline-rows: {{ $rows }}; --timeline-step: {{ $stepVh }}vh;">
+  {{/* First in the DOM and zero height, so it can park in the middle of the
+       viewport for the whole section without moving a single card. */}}
+  <div class="timeline-dates" aria-hidden="true">
+    {{- range $project := $projects -}}
+      <span class="timeline-date" style="--from: {{ $project.from | safeCSS }}; --to: {{ $project.to | safeCSS }};">{{ $project.date }}</span>
+    {{- end -}}
+  </div>
+
+  <div class="timeline-inner">
+    <div class="timeline-rail" aria-hidden="true">
+      {{- range $project := $projects -}}
+        <span class="timeline-tick"></span>
+      {{- end -}}
+    </div>
+
+    <div class="timeline-cards">
+      {{- range $index, $project := $projects -}}
+        <article class="timeline-card timeline-card--{{ if eq (mod $index 2) 0 }}left{{ else }}right{{ end }}">
+          <p class="timeline-card-date">{{ $project.date }}</p>
+          <h3 class="timeline-card-title">{{ $project.title }}</h3>
+          {{- with $project.description }}
+            <div class="timeline-card-description">{{ . | markdownify }}</div>
           {{- end -}}
-        </div>
-
-        <div class="timeline-cards">
-          {{- range $index, $project := $projects -}}
-            <article class="timeline-card timeline-card--{{ if eq (mod $index 2) 0 }}left{{ else }}right{{ end }}">
-              <p class="timeline-card-date">{{ $project.date }}</p>
-              <h3 class="timeline-card-title">{{ $project.title }}</h3>
-              {{- with $project.description }}
-                <div class="timeline-card-description">{{ . | markdownify }}</div>
-              {{- end -}}
-              <div class="timeline-card-links">
-                {{- with $project.slug }}
-                  <a class="timeline-card-more" href="{{ printf "/projects/%s/" . | relURL }}">read more &rarr;</a>
-                {{- end -}}
-                {{- with $project.link }}{{ . | markdownify }}{{ end -}}
-              </div>
-            </article>
-          {{- end -}}
-        </div>
-
-      </div>
-      {{/* Outside the scrolling layer, so it can hold the middle slot. Only the
-           project currently being read shows its date here. */}}
-      <div class="timeline-dates" aria-hidden="true">
-        {{- range $index, $project := $projects -}}
-          <span class="timeline-date{{ if eq $project.fromN $project.toN }} timeline-date--inactive{{ else }}{{ if eq $project.fromN $viewStartN }} timeline-date--range-start{{ end }}{{ if eq $project.toN $viewEndN }} timeline-date--range-end{{ end }}{{ if and (eq $project.fromN $viewStartN) (eq $project.toN $viewEndN) }} timeline-date--range-hold{{ end }}{{ end }}" style="--from: {{ $project.from | safeCSS }}; --to: {{ $project.to | safeCSS }};">{{ $project.date }}</span>
-        {{- end -}}
-      </div>
-
-      <span class="timeline-scroll-hint" aria-hidden="true">scroll to explore</span>
+          <div class="timeline-card-links">
+            {{- with $project.slug }}
+              <a class="timeline-card-more" href="{{ printf "/projects/%s/" . | relURL }}">read more &rarr;</a>
+            {{- end -}}
+            {{- with $project.link }}{{ . | markdownify }}{{ end -}}
+          </div>
+        </article>
+      {{- end -}}
     </div>
   </div>
 </section>


### PR DESCRIPTION
Follow-up to #63, which shipped a version that still had both problems. Rewrites the timeline by removing the mechanism that caused them.

### Why the pinned version could not work

Pinning centred the active card inside a 100vh viewport. Centring the *first* card means roughly half a screen of empty space above it, and centring the *last* card means the same below. That empty space is the two dead zones, and it is not a bug in the maths, it is what centring inside a pin means.

Shrinking the travel to close the gaps had the opposite failure: content ended up only 8vh taller than the pin, so the entire run animated over **72px** of scroll and the date windows collapsed into a 3.8% band.

The two requirements were in direct conflict. So the pin is gone.

### What it does now

The cards are an ordinary vertical list of five equal 26vh rows. No pinning, no transform, no runway. **The dead zones are gone by construction**, because there is no pinned viewport to leave empty.

Only the floating date uses a scroll-driven animation. It is a zero-height sticky element parked at `50vh`, so it holds the middle of the screen for the whole section without moving a single card. Each label is painted for exactly the stretch where its own card crosses the centre line:

```
progress(y) = (y + 50vh) / (section height + 100vh)
```

Five 26vh rows tile `21.739%` to `78.260%` as five equal `11.304%` windows, adjacent, no gap and no overlap. Outside its range the animation does not apply at all, so the label falls back to its base `opacity: 0` and no second keyframe is needed to hide it.

### Verified by screenshot, not by assertion

| Scroll | Date shown | Position |
|---|---|---|
| 567 | Jul 2026 | y=447, on the pi-terminal-kit card centre and its tick |
| 1035 | Dec 2025 | y=447, on the Restaurant Application card centre and its tick |
| 1503 | May 2025 | y=447, on the Home Server + LLM card centre and its tick |

Viewport centre is 450. The date is on the centre line, aligned with the card it names, at every position.

- Gap under `PROJECTS` before the first card: about 70px, was about 800px.
- Gap after the last card before `WRITING`: about 137px, was about 800px.
- No horizontal overflow: 1440 `1425/1425`, 768 `753/753`, 390 `375/375`.
- 390px stacks full width with no rail and no floating date.
- `hugo --gc --minify`: zero errors, zero warnings.

### Fallbacks got simpler

The layout no longer depends on scroll-driven animation for anything structural, so Firefox and `prefers-reduced-motion` keep the rail and the cards and lose only the floating label. Every card already prints its own date, so nothing is lost.

Net **204 lines removed**.
