### PR TITLE
ci: add GitHub Pages pull request previews

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,17 +1,21 @@
-# Build Hugo and publish the production site to the gh-pages branch.
-name: pages-deploy
+name: Deploy PR previews
 
 on:
-  push:
+  pull_request:
     branches:
       - main
-  workflow_dispatch:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - closed
 
 permissions:
   contents: write
+  pull-requests: write
 
 concurrency:
-  group: pages-deploy
+  group: "pr-preview-${{ github.event.number }}"
   cancel-in-progress: false
 
 defaults:
@@ -19,16 +23,17 @@ defaults:
     shell: bash
 
 jobs:
-  deploy:
+  deploy-preview:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
+      - name: Checkout repository
         uses: actions/checkout@v7
         with:
           submodules: recursive
           fetch-depth: 0
 
       - name: Read Hugo version
+        if: github.event.action != 'closed'
         run: |
           HUGO_VERSION="$(tr -d '[:space:]' < .hugo-version)"
           if [[ ! "$HUGO_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
@@ -38,35 +43,42 @@ jobs:
           echo "HUGO_VERSION=$HUGO_VERSION" >> "$GITHUB_ENV"
 
       - name: Install Hugo CLI
+        if: github.event.action != 'closed'
         run: |
           wget -O ${{ runner.temp }}/hugo.deb "https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb"
           sudo dpkg -i ${{ runner.temp }}/hugo.deb
 
       - name: Verify Hugo Version
+        if: github.event.action != 'closed'
         run: hugo version
 
       - name: Enforce Hugo minimum version
+        if: github.event.action != 'closed'
         run: python3 scripts/check-hugo-version.py
 
       - name: Install Dart Sass
+        if: github.event.action != 'closed'
         run: sudo snap install dart-sass
 
       - name: Install Node.js dependencies
+        if: github.event.action != 'closed'
         run: "[[ -f package-lock.json || -f npm-shrinkwrap.json ]] && npm ci || true"
 
-      - name: Build with Hugo
+      - name: Build preview with Hugo
+        if: github.event.action != 'closed'
         env:
           HUGO_ENVIRONMENT: production
           HUGO_ENV: production
         run: |
-          hugo --gc --minify --baseURL "https://isaaclins.com/"
+          hugo --gc --minify --baseURL "https://isaaclins.com/pr-preview/pr-${{ github.event.number }}/"
 
-      - name: Publish production site
-        uses: JamesIves/github-pages-deploy-action@v4
+      - name: Deploy or remove preview
+        uses: rossjrw/pr-preview-action@v1
         with:
           token: ${{ github.token }}
-          branch: gh-pages
-          folder: ./public
-          clean-exclude: pr-preview/
-          single-commit: false
-          force: false
+          source-dir: ./public
+          preview-branch: gh-pages
+          pages-base-url: isaaclins.com
+          action: auto
+          wait-for-pages-deployment: false
+          qr-code: false

--- a/README.md
+++ b/README.md
@@ -47,7 +47,16 @@ hugo --gc --minify     # production build into ./public
 - **build-test** — builds the site, validates the generated HTML with
   `html5validator`, and runs `cspell` on non-draft content for pushes to `main`
   and pull requests targeting `main`.
-- **pages-deploy** — builds and deploys to GitHub Pages on push to `main`.
+- **pages-deploy** — builds the production site and publishes it to the
+  `gh-pages` branch on push to `main`.
+- **PR previews** — builds each pull request targeting `main` and publishes it
+  at `https://isaaclins.com/pr-preview/pr-<number>/`. The pull request preview
+  workflow uses `rossjrw/pr-preview-action` and removes the preview when the
+  pull request closes.
+- GitHub Pages must be set to **Deploy from a branch**, using `gh-pages` and the
+  repository root. The site must keep [`static/CNAME`](static/CNAME) with the
+  exact contents `isaaclins.com`; Hugo copies it to `public/CNAME` so branch
+  deployments keep the custom domain.
 - Both Hugo workflows read the pinned version from [`.hugo-version`](.hugo-version)
   and enforce `config.toml`'s minimum with `scripts/check-hugo-version.py`;
   update the version file when upgrading Hugo.

--- a/static/CNAME
+++ b/static/CNAME
@@ -1,0 +1,1 @@
+isaaclins.com


### PR DESCRIPTION
## What changed

- Publish the Hugo production build to `gh-pages` with `JamesIves/github-pages-deploy-action`.
- Preserve `pr-preview/` during production deploys with `clean-exclude: pr-preview/`, `single-commit: false`, and `force: false`.
- Add `static/CNAME` with the exact contents `isaaclins.com`.
- Build pull request previews with `rossjrw/pr-preview-action` at `https://isaaclins.com/pr-preview/pr-<number>/` and remove them when the pull request closes.
- Document the Pages source and CNAME requirements.

## Cutover sequence

1. Merge this pull request.
2. Confirm the `gh-pages` branch is populated by `pages-deploy` and its root `CNAME` contains `isaaclins.com`.
3. Flip the GitHub Pages source to deploy from the `gh-pages` branch at the repository root.
4. Verify that `https://isaaclins.com/` still serves the production site.
5. Only then expect new or updated pull requests to receive previews.

This pull request does not change the GitHub Pages setting. It must remain `workflow` until the branch deployment is populated and checked.
