### PR TITLE
Breadcrumbs should show the page title, not a guess from the filename

### DIFF
--- a/layouts/partials/breadcrumbs.html
+++ b/layouts/partials/breadcrumbs.html
@@ -1,6 +1,3 @@
-{{ $url := replace .Permalink (printf "%s" .Site.BaseURL) "" }}
-{{ $urlParts := split $url "/" }}
-
 <div class="breadcrumbs">
   <div>
     <a href="{{ "/" | relURL }}">Home</a>
@@ -10,7 +7,10 @@
       {{ end }}
     {{ end }}
     {{ if not .IsHome }}
-        / <a href="{{ .Permalink }}">{{ if .IsPage }}{{ .File.BaseFileName | humanize }}{{ else }}{{ .Title }}{{ end }}</a>
+        {{/* LinkTitle, not the humanized filename. Humanizing turned
+             pi-terminal-kit into "Pi terminal kit" and threw away the title
+             the page actually declares. */}}
+        / <a href="{{ .Permalink }}">{{ .LinkTitle }}</a>
     {{ end }}
   </div>
 


### PR DESCRIPTION
The last breadcrumb was derived from the *filename* run through `humanize`, so it title-cased everything and threw away the title the page actually declares.

| Page | Before | After |
|---|---|---|
| `/projects/pi-terminal-kit/` | Pi terminal kit | **pi-terminal-kit** |
| `/blog/git-wasnt-built-for-agents/` | Git wasnt built for agents | **Git wasn%27t built for agents** |

The blog case is the one I did not expect: humanizing a slug cannot recover punctuation, so every post title silently lost its apostrophes in the trail.

`LinkTitle` falls back to `Title`, so the crumb now matches the heading on the page.

Also deletes two variables at the top of the partial that were computed and never used.

Verified with `hugo --gc --minify`, zero errors and zero warnings, and by reading the rendered breadcrumb out of three built pages including a section index.

This PR doubles as the first real use of the preview pipeline, so the rendered result should be visible at the preview URL below.