### PR TITLE
Fix the preview reaper: it never actually read a PR state

### DIFF
--- a/.github/workflows/pr-preview-reaper.yml
+++ b/.github/workflows/pr-preview-reaper.yml
@@ -68,7 +68,10 @@ jobs:
 
             response_file="$(mktemp)"
             api_exit=0
-            gh api --include --silent "repos/$REPOSITORY/pulls/$pr_number" >"$response_file" || api_exit=$?
+            # No --silent here. It suppresses the response body, which leaves the
+            # file holding headers only, so the state parse below finds nothing
+            # and every run dies on the first preview it inspects.
+            gh api --include "repos/$REPOSITORY/pulls/$pr_number" >"$response_file" || api_exit=$?
             status_code="$(awk '/^HTTP\/[^ ]+ / { code=$2 } END { print code }' "$response_file")"
 
             if (( api_exit == 0 )); then


### PR DESCRIPTION
The reaper merged in #68 fails on the first preview directory it inspects:

```
::error::GitHub API returned no pull request state for PR #67
::error::Process completed with exit code 1
```

## Cause

```bash
gh api --include --silent "repos/$REPOSITORY/pulls/$pr_number"
```

`--include` asks for the response headers, `--silent` suppresses the response **body**. Together they write a file containing headers and no JSON, so `jq -r .state` returns empty and the script exits 1.

Confirmed by running both forms against the live API:

| Command | `.state` |
|---|---|
| `gh api --include --silent .../pulls/67` | *(empty)* |
| `gh api --include .../pulls/67` | `open` |

The 404 path still works without `--silent`, verified against a nonexistent PR number, so the missing-PR branch is unaffected.

## Why it shipped

The only dry run was executed while `pr-preview/` did not exist, so it printed `would delete: none` without ever entering the loop that calls the API. The passing check covered the empty case only.

## Impact if left

The daily cron fails every day and no preview is ever reaped, which is the exact accumulation problem #68 set out to fix.